### PR TITLE
Lower case polymer dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,6 +19,6 @@
     "/demo/"
   ],
   "dependencies": {
-    "Polymer": "Polymer/polymer#0.8-preview"
+    "polymer": "Polymer/polymer#0.8-preview"
   }
 }


### PR DESCRIPTION
On case-sensitive filesystems the capitalization was causing Polymer to double-install in the bower_components directory.