### PR TITLE
RobotoDraft -> Roboto and shadows

### DIFF
--- a/demo.css
+++ b/demo.css
@@ -1,5 +1,5 @@
 body {
-  font-family: RobotoDraft, 'Helvetica Neue', Helvetica, Arial;
+  font-family: 'Roboto', 'Noto', sans-serif;
   font-size: 14px;
   margin: 0;
   padding: 24px;

--- a/shadow.html
+++ b/shadow.html
@@ -30,31 +30,31 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     --shadow-elevation-3dp: {
       box-shadow: 0 3px 4px 0 rgba(0, 0, 0, 0.14),
                   0 1px 8px 0 rgba(0, 0, 0, 0.12),
-                  0 3px 3px -2px rgba(0, 0, 0, 0.2);
+                  0 3px 3px -2px rgba(0, 0, 0, 0.4);
     };
 
     --shadow-elevation-4dp: {
       box-shadow: 0 4px 5px 0 rgba(0, 0, 0, 0.14),
                   0 1px 10px 0 rgba(0, 0, 0, 0.12),
-                  0 2px 4px -1px rgba(0, 0, 0, 0.2);
+                  0 2px 4px -1px rgba(0, 0, 0, 0.4);
     };
 
     --shadow-elevation-6dp: {
       box-shadow: 0 6px 10px 0 rgba(0, 0, 0, 0.14),
                   0 1px 18px 0 rgba(0, 0, 0, 0.12),
-                  0 3px 5px -1px rgba(0, 0, 0, 0.2);
+                  0 3px 5px -1px rgba(0, 0, 0, 0.4);
     };
 
     --shadow-elevation-8dp: {
       box-shadow: 0 8px 10px 1px rgba(0, 0, 0, 0.14),
                   0 3px 14px 2px rgba(0, 0, 0, 0.12),
-                  0 5px 5px -3px rgba(0, 0, 0, 0.2);
+                  0 5px 5px -3px rgba(0, 0, 0, 0.4);
     };
 
     --shadow-elevation-16dp: {
       box-shadow: 0 16px 24px 2px rgba(0, 0, 0, 0.14),
                   0  6px 30px 5px rgba(0, 0, 0, 0.12),
-                  0  8px 10px -5px rgba(0, 0, 0, 0.2);
+                  0  8px 10px -5px rgba(0, 0, 0, 0.4);
     };
 
   }


### PR DESCRIPTION
**Material design spec audit https://github.com/PolymerElements/paper-button/issues/12**

* Use `Roboto', 'Noto', sans-serif` instead of `RobotoDraft` in the demos.
* Make the shadows a bit stronger as it's required by the spec. This change should also solve https://github.com/PolymerElements/paper-button/issues/10

cc @cdata @notwaldorf 