### PR TITLE
fix centered vertical-section's size on mobile

### DIFF
--- a/demo-pages.html
+++ b/demo-pages.html
@@ -51,7 +51,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   }
 
   .centered {
-    width: 400px;
+    max-width: 400px;
     margin-left: auto;
     margin-right: auto;
   }


### PR DESCRIPTION
Fixed sizes are sad on mobile, and they make the demo too wide. I haven't found code that sets a different width for this, so this shouldn't break any existing demos. I really shouldn't be allowed to write CSS :(

/cc @morethanreal @cdata @blasten 

Before:
![screen shot 2015-05-28 at 11 19 44 pm](https://cloud.githubusercontent.com/assets/1369170/7877488/08b57482-0591-11e5-864c-3631162c8c5d.png)

After:
![screen shot 2015-05-28 at 11 19 00 pm](https://cloud.githubusercontent.com/assets/1369170/7877486/075efca2-0591-11e5-9578-c9b288675be7.png)


