### PR TITLE
Fix brown colors in color.html

### DIFF
--- a/color.html
+++ b/color.html
@@ -283,9 +283,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     --paper-deep-orange-a400: #ff3d00;
     --paper-deep-orange-a700: #dd2c00;
  
-    --paper-brown-50: #795548;
-    --paper-brown-100: #efebe9;
-    --paper-brown-200: #d7ccc8;
+    --paper-brown-50: #efebe9;
+    --paper-brown-100: #d7ccc8;
+    --paper-brown-200: #bcaaa4;
     --paper-brown-300: #a1887f;
     --paper-brown-400: #8d6e63;
     --paper-brown-500: #795548;


### PR DESCRIPTION
The paper-brown colors 50-200 do not match the color palette here: http://www.google.com/design/spec/style/color.html#color-color-palette
Fixed colors to match.