### PR TITLE
Prevent cssmin breaking box-shadow format for dialogs

### DIFF
--- a/classes/shadow.html
+++ b/classes/shadow.html
@@ -14,39 +14,39 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 }
 
 .shadow-elevation-2dp {
-  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14),
-              0 1px 5px 0 rgba(0, 0, 0, 0.12),
-              0 3px 1px -2px rgba(0, 0, 0, 0.2);
+  box-shadow: 0px 2px 2px 0px rgba(0, 0, 0, 0.14),
+              0px 1px 5px 0px rgba(0, 0, 0, 0.12),
+              0px 3px 1px -2px rgba(0, 0, 0, 0.2);
 }
 
 .shadow-elevation-3dp {
-  box-shadow: 0 3px 4px 0 rgba(0, 0, 0, 0.14),
-              0 1px 8px 0 rgba(0, 0, 0, 0.12),
-              0 3px 3px -2px rgba(0, 0, 0, 0.4);
+  box-shadow: 0px 3px 4px 0px rgba(0, 0, 0, 0.14),
+              0px 1px 8px 0px rgba(0, 0, 0, 0.12),
+              0px 3px 3px -2px rgba(0, 0, 0, 0.4);
 }
 
 .shadow-elevation-4dp {
-  box-shadow: 0 4px 5px 0 rgba(0, 0, 0, 0.14),
-              0 1px 10px 0 rgba(0, 0, 0, 0.12),
-              0 2px 4px -1px rgba(0, 0, 0, 0.4);
+  box-shadow: 0px 4px 5px 0px rgba(0, 0, 0, 0.14),
+              0px 1px 10px 0px rgba(0, 0, 0, 0.12),
+              0px 2px 4px -1px rgba(0, 0, 0, 0.4);
 }
 
 .shadow-elevation-6dp {
-  box-shadow: 0 6px 10px 0 rgba(0, 0, 0, 0.14),
-              0 1px 18px 0 rgba(0, 0, 0, 0.12),
-              0 3px 5px -1px rgba(0, 0, 0, 0.4);
+  box-shadow: 0px 6px 10px 0px rgba(0, 0, 0, 0.14),
+              0px 1px 18px 0px rgba(0, 0, 0, 0.12),
+              0px 3px 5px -1px rgba(0, 0, 0, 0.4);
 }
 
 .shadow-elevation-8dp {
-  box-shadow: 0 8px 10px 1px rgba(0, 0, 0, 0.14),
-              0 3px 14px 2px rgba(0, 0, 0, 0.12),
-              0 5px 5px -3px rgba(0, 0, 0, 0.4);
+  box-shadow: 0px 8px 10px 1px rgba(0, 0, 0, 0.14),
+              0px 3px 14px 2px rgba(0, 0, 0, 0.12),
+              0px 5px 5px -3px rgba(0, 0, 0, 0.4);
 }
 
 .shadow-elevation-16dp {
-  box-shadow: 0 16px 24px 2px rgba(0, 0, 0, 0.14),
-              0  6px 30px 5px rgba(0, 0, 0, 0.12),
-              0  8px 10px -5px rgba(0, 0, 0, 0.4);
+  box-shadow: 0px 16px 24px 2px rgba(0, 0, 0, 0.14),
+              0px  6px 30px 5px rgba(0, 0, 0, 0.12),
+              0px  8px 10px -5px rgba(0, 0, 0, 0.4);
 }
 
 </style>

--- a/shadow.html
+++ b/shadow.html
@@ -25,39 +25,39 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     /* from http://codepen.io/shyndman/pen/c5394ddf2e8b2a5c9185904b57421cdb */
 
     --shadow-elevation-2dp: {
-      box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14),
-                  0 1px 5px 0 rgba(0, 0, 0, 0.12),
-                  0 3px 1px -2px rgba(0, 0, 0, 0.2);
+      box-shadow: 0px 2px 2px 0px rgba(0, 0, 0, 0.14),
+                  0px 1px 5px 0px rgba(0, 0, 0, 0.12),
+                  0px 3px 1px -2px rgba(0, 0, 0, 0.2);
     };
 
     --shadow-elevation-3dp: {
-      box-shadow: 0 3px 4px 0 rgba(0, 0, 0, 0.14),
-                  0 1px 8px 0 rgba(0, 0, 0, 0.12),
-                  0 3px 3px -2px rgba(0, 0, 0, 0.4);
+      box-shadow: 0px 3px 4px 0px rgba(0, 0, 0, 0.14),
+                  0px 1px 8px 0px rgba(0, 0, 0, 0.12),
+                  0px 3px 3px -2px rgba(0, 0, 0, 0.4);
     };
 
     --shadow-elevation-4dp: {
-      box-shadow: 0 4px 5px 0 rgba(0, 0, 0, 0.14),
-                  0 1px 10px 0 rgba(0, 0, 0, 0.12),
-                  0 2px 4px -1px rgba(0, 0, 0, 0.4);
+      box-shadow: 0px 4px 5px 0px rgba(0, 0, 0, 0.14),
+                  0px 1px 10px 0px rgba(0, 0, 0, 0.12),
+                  0px 2px 4px -1px rgba(0, 0, 0, 0.4);
     };
 
     --shadow-elevation-6dp: {
-      box-shadow: 0 6px 10px 0 rgba(0, 0, 0, 0.14),
-                  0 1px 18px 0 rgba(0, 0, 0, 0.12),
-                  0 3px 5px -1px rgba(0, 0, 0, 0.4);
+      box-shadow: 0px 6px 10px 0px rgba(0, 0, 0, 0.14),
+                  0px 1px 18px 0px rgba(0, 0, 0, 0.12),
+                  0px 3px 5px -1px rgba(0, 0, 0, 0.4);
     };
 
     --shadow-elevation-8dp: {
-      box-shadow: 0 8px 10px 1px rgba(0, 0, 0, 0.14),
-                  0 3px 14px 2px rgba(0, 0, 0, 0.12),
-                  0 5px 5px -3px rgba(0, 0, 0, 0.4);
+      box-shadow: 0px 8px 10px 1px rgba(0, 0, 0, 0.14),
+                  0px 3px 14px 2px rgba(0, 0, 0, 0.12),
+                  0px 5px 5px -3px rgba(0, 0, 0, 0.4);
     };
 
     --shadow-elevation-16dp: {
-      box-shadow: 0 16px 24px 2px rgba(0, 0, 0, 0.14),
-                  0  6px 30px 5px rgba(0, 0, 0, 0.12),
-                  0  8px 10px -5px rgba(0, 0, 0, 0.4);
+      box-shadow: 0px 16px 24px 2px rgba(0, 0, 0, 0.14),
+                  0px  6px 30px 5px rgba(0, 0, 0, 0.12),
+                  0px  8px 10px -5px rgba(0, 0, 0, 0.4);
     };
 
   }


### PR DESCRIPTION
I've picked up Polymer with the Starter Kit. When serving the app from its source, paper-dialogs have shadows. However, when I run gulp on my app, they have no shadow. Oddly enough, other elements' shadows (e.g. paper-material) appear to be fine. I found that what should have been
`0 16px 24px 2px rgba(0, 0, 0, 0.14), 0 6px 30px 5px rgba(0, 0, 0, 0.12), 0 8px 10px -5px rgba(0, 0, 0, 0.4)`
was 
`0 16px 24px 2px rgba(0, 0, 0, 0.14),06px 30px 5px rgba(0, 0, 0, 0.12),08px 10px -5px rgba(0, 0, 0, 0.4)`
after running cssmin. After adding units to the 0s, this doesn't happen.