### PR TITLE
Opacity for dark text mismatches with Material Design specification

### DIFF
--- a/color.html
+++ b/color.html
@@ -318,14 +318,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     /* opacity for dark text on a light background */
     --dark-divider-opacity: 0.12;
-    --dark-disabled-opacity: 0.26; /* or hint text */
-    --dark-secondary-opacity: 0.54; /* or icon */
+    --dark-disabled-opacity: 0.38; /* or hint text or icon */
+    --dark-secondary-opacity: 0.54;
     --dark-primary-opacity: 0.87;
 
     /* opacity for light text on a dark background */
     --light-divider-opacity: 0.12;
-    --light-disabled-opacity: 0.3; /* or hint text */
-    --light-secondary-opacity: 0.7; /* or icon */
+    --light-disabled-opacity: 0.3; /* or hint text or icon */
+    --light-secondary-opacity: 0.7;
     --light-primary-opacity: 1.0;
 
   }


### PR DESCRIPTION
The Material Design specifications says that icons with dark text should use an opacity of 38% (https://www.google.com/design/spec/style/color.html#color-ui-color-application).

Paper-styles indicates that icons should use the secondary opacity (54%) (https://github.com/PolymerElements/paper-styles/blob/master/color.html#L322)

Additionally, the spec says that the hint/disabled opacity should be 38% whereas paper-styles implements 26%.

Fixes#67