### PR TITLE
Use transparency instead of grey text as advised by Material Design specification

### DIFF
--- a/default-theme.html
+++ b/default-theme.html
@@ -26,13 +26,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     --primary-background-color: #ffffff;
 
-    --primary-text-color: #212121;
+    --primary-text-color: rgba(0,0,0,.87);
 
-    --secondary-text-color: #757575;
+    --secondary-text-color: rgba(0,0,0,.54);
 
-    --disabled-text-color: #bdbdbd;
+    --disabled-text-color: rgba(0,0,0,.38);
 
-    --divider-color: #e0e0e0;
+    --divider-color: rgba(0,0,0,.12);
 
   }
 


### PR DESCRIPTION
The Material Design specification advises to use transparency instead of
grey text:
"Transparent black or white text behaves more flexibly than grey text
because it remains legible and vibrant against background color
changes."

Suggested by robrez in
https://github.com/PolymerElements/paper-styles/issues/60

Fixes#60