### PR TITLE
Inset depression shadow.

### DIFF
--- a/shadow.html
+++ b/shadow.html
@@ -60,6 +60,42 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                   0  8px 10px -5px rgba(0, 0, 0, 0.4);
     };
 
+    --shadow-depression-2dp: {
+      box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14) inset,
+      0 1px 5px 0 rgba(0, 0, 0, 0.12) inset,
+      0 3px 1px -2px rgba(0, 0, 0, 0.2) inset;
+    };
+
+    --shadow-depression-3dp: {
+      box-shadow: 0 3px 4px 0 rgba(0, 0, 0, 0.14) inset,
+      0 1px 8px 0 rgba(0, 0, 0, 0.12) inset,
+      0 3px 3px -2px rgba(0, 0, 0, 0.4) inset;
+    };
+
+    --shadow-depression-4dp: {
+      box-shadow: 0 4px 5px 0 rgba(0, 0, 0, 0.14) inset,
+      0 1px 10px 0 rgba(0, 0, 0, 0.12) inset,
+      0 2px 4px -1px rgba(0, 0, 0, 0.4) inset;
+    };
+
+    --shadow-depression-6dp: {
+      box-shadow: 0 6px 10px 0 rgba(0, 0, 0, 0.14) inset,
+      0 1px 18px 0 rgba(0, 0, 0, 0.12) inset,
+      0 3px 5px -1px rgba(0, 0, 0, 0.4) inset;
+    };
+
+    --shadow-depression-8dp: {
+      box-shadow: 0 8px 10px 1px rgba(0, 0, 0, 0.14) inset,
+      0 3px 14px 2px rgba(0, 0, 0, 0.12) inset,
+      0 5px 5px -3px rgba(0, 0, 0, 0.4) inset;
+    };
+
+    --shadow-depression-16dp: {
+      box-shadow: 0 16px 24px 2px rgba(0, 0, 0, 0.14) inset,
+      0  6px 30px 5px rgba(0, 0, 0, 0.12) inset,
+      0  8px 10px -5px rgba(0, 0, 0, 0.4) inset;
+    };
+
   }
 
 </style>


### PR DESCRIPTION
close issue Polymer/paper-shadow#11 from pre Polymer 1.0

Bringing feature request from before current Polymer version 1.0 up to current version.

Basically allows for inset shadows. Will be updating PolymerElements/paper-material to reflect the changes in documentation as well.