### PR TITLE
clean up default-theme values

### DIFF
--- a/default-theme.html
+++ b/default-theme.html
@@ -49,24 +49,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     /*
      * Deprecated values because of their confusing names.
      */
-
-    /* Use --light-theme-text-color instead */
-    --primary-text-color: #212121;
-
-    /* Use --dark-theme-text-color instead */
-    --text-primary-color: #ffffff;
-
-    /* Use --light-theme-background-color instead */
-    --primary-background-color: #ffffff;
-
-    /* Use --light-theme-secondary-color */
-    --secondary-text-color: #757575;
-
-    /* Use --light-theme-disabled-color instead */
-    --disabled-text-color: #bdbdbd;
-
-    /* Use --light-theme-divider-color instead */
-    --divider-color: #e0e0e0;
+    --primary-text-color: var(--light-theme-text-color);
+    --text-primary-color: var(--dark-theme-text-color);
+    --primary-background-color: var(--light-theme-background-color);
+    --secondary-text-color: var(--light-theme-secondary-color);
+    --disabled-text-color:var(--light-theme-disabled-color);
+    --divider-color: var(--light-theme-divider-color);
   }
 
 </style>

--- a/default-theme.html
+++ b/default-theme.html
@@ -10,30 +10,63 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <link rel="import" href="../polymer/polymer.html">
 
+<!-- Taken from https://www.google.com/design/spec/style/color.html#color-ui-color-application -->
+
 <style is="custom-style">
 
   :root {
+    /*
+     * Light background theme
+     */
+    --light-theme-background-color: #ffffff;
+    --light-theme-base-color: #000000;
+    --light-theme-text-color: #212121;
+    --light-theme-secondary-color: #737373;  /* for secondary text and icons */
+    --light-theme-disabled-color: #9b9b9b;  /* disabled/hint text */
+    --light-theme-divider-color: #dbdbdb;
 
-    --dark-primary-color: #303f9f;
+    /*
+     * Dark background theme
+     */
+    --dark-theme-background-color: #212121;
+    --dark-theme-base-color: #ffffff;
+    --dark-theme-text-color: #ffffff;
+    --dark-theme-secondary-color: #bcbcbc;  /* for secondary text and icons */
+    --dark-theme-disabled-color: #646464;  /* disabled/hint text */
+    --dark-theme-divider-color: #3c3c3c;
 
-    --default-primary-color: #3f51b5;
+    /*
+     * Primary and accent colors. Also see color.html for more colors.
+     */
+    --light-primary-color: #c5cae9;  /* --paper-indigo-100 */
+    --default-primary-color: #3f51b5;  /* --paper-indigo-500 */
+    --dark-primary-color: #303f9f;  /* --paper-indigo-700 */
 
-    --light-primary-color: #c5cae9;
+    --accent-color: #ff4081;  /* --paper-pink-a200 */
+    --light-accent-color: #ff80ab;  /* --paper-pink-a100 */
+    --dark-accent-color: #f50057;  /* --paper-pink-a400 */
 
-    --text-primary-color: #ffffff;
+    /*
+     * Deprecated values because of their confusing names.
+     */
 
-    --accent-color: #ff4081;
-
-    --primary-background-color: #ffffff;
-
+    /* Use --light-theme-text-color instead */
     --primary-text-color: #212121;
 
+    /* Use --dark-theme-text-color instead */
+    --text-primary-color: #ffffff;
+
+    /* Use --light-theme-background-color instead */
+    --primary-background-color: #ffffff;
+
+    /* Use --light-theme-secondary-color */
     --secondary-text-color: #757575;
 
+    /* Use --light-theme-disabled-color instead */
     --disabled-text-color: #bdbdbd;
 
+    /* Use --light-theme-divider-color instead */
     --divider-color: #e0e0e0;
-
   }
 
 </style>


### PR DESCRIPTION
I've added new theme-suffixed variables for the colors in https://www.google.com/design/spec/style/color.html#color-ui-color-application. I've added a "deprecated" section with all the weirdly named vestigial ones, and I've marked what they correspond to in this brave new world.

Fixes https://github.com/PolymerElements/paper-styles/issues/81, https://github.com/PolymerElements/polymer-starter-kit/issues/436