### PR TITLE
added own dependencies to main

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,13 @@
     "type": "git",
     "url": "git://github.com/PolymerElements/paper-styles.git"
   },
-  "main": "paper-styles.html",
+  "main": [
+  	"paper-styles.html",
+  	"color.html",
+  	"default-theme.html",
+  	"shadow.html",
+  	"typography.html"
+  ],
   "license": "http://polymer.github.io/LICENSE.txt",
   "homepage": "https://github.com/polymerelements/paper-styles/",
   "ignore": [


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/paper-styles/issues/84

Added own dependencies to main so that things like [bower-installer](https://github.com/blittle/bower-installer) work correctly when copying over main files to custom folders.