### PR TITLE
minor name cleanup

### DIFF
--- a/default-theme.html
+++ b/default-theme.html
@@ -38,8 +38,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     /*
      * Primary and accent colors. Also see color.html for more colors.
      */
+    --primary-color: #3f51b5;  /* --paper-indigo-500 */
     --light-primary-color: #c5cae9;  /* --paper-indigo-100 */
-    --default-primary-color: #3f51b5;  /* --paper-indigo-500 */
     --dark-primary-color: #303f9f;  /* --paper-indigo-700 */
 
     --accent-color: #ff4081;  /* --paper-pink-a200 */
@@ -55,6 +55,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     --secondary-text-color: var(--light-theme-secondary-color);
     --disabled-text-color:var(--light-theme-disabled-color);
     --divider-color: var(--light-theme-divider-color);
+    --default-primary-color: var(--primary-color);
   }
 
 </style>


### PR DESCRIPTION
This was one of the other old names leftover from the previous theme, and as someone mentioned in https://github.com/PolymerElements/paper-styles/pull/82#discussion_r47791851, `primary-color` better matches `accent-color` (sans the default)