### PR TITLE
Replace <header> with <h1> in classes/typography example.

### DIFF
--- a/classes/typography.html
+++ b/classes/typography.html
@@ -16,7 +16,7 @@ http://www.google.com/design/spec/style/typography.html#typography-standard-styl
 To make use of them, apply a `paper-font-<style>` class to elements, matching
 the font style you wish it to inherit.
 
-  <header class="paper-font-display2">Hey there!</header>
+  <h1 class="paper-font-display2">Hey there!</h1>
 
 Note that these are English/Latin centric styles. You may need to further adjust
 line heights and weights for CJK typesetting. See the notes in the Material


### PR DESCRIPTION
<header> is for a "heading" section rather than the heading itself. HTML5 has
a note saying

> A header element is intended to usually contain the section's heading (an h1–h6 element), [---]

indicating this is indeed not meant has a heading. `display2` is used for
`<h1>` in global.html, so use that as an example instead.

Closes #108.