### PR TITLE
Added shadow elevation 24dp

### DIFF
--- a/shadow.html
+++ b/shadow.html
@@ -66,6 +66,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                   0  8px 10px -5px rgba(0, 0, 0, 0.4);
     };
 
+    --shadow-elevation-24dp: {
+      box-shadow: 0 24px 38px 3px rgba(0, 0, 0, 0.14),
+                  0 9px 46px 8px rgba(0, 0, 0, 0.12),
+                  0 11px 15px -7px rgba(0, 0, 0, 0.4);
+    };
   }
 
 </style>


### PR DESCRIPTION
This PR fixes #112

According to the material design documentation, the shadow elevation rises up to 24 dp, concretely this level is used for _dialog_ and _picker_ components.