### PR TITLE
Add deprecation warning to file using /deep/

### DIFF
--- a/classes/shadow-layout.html
+++ b/classes/shadow-layout.html
@@ -7,6 +7,11 @@ The complete set of contributors may be found at http://polymer.github.io/CONTRI
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
+
+<script>
+  console.warn('This file is deprecated. Please use `iron-flex-layout/iron-flex-layout-classes.html`, and one of the specific dom-modules instead');
+</script>
+
 <style>
 
   /*******************************


### PR DESCRIPTION
shadow-layout.html looks like a clone of iron-shadow-flex-layout.html so I copied the warning from there: https://github.com/PolymerElements/iron-flex-layout/blob/master/classes/iron-shadow-flex-layout.html