### PR TITLE
add paper-item and paper-material as standalone styles

### DIFF
--- a/element-styles/paper-item.html
+++ b/element-styles/paper-item.html
@@ -58,7 +58,7 @@ Shared styles for a native `button` to be used as an item in a `paper-listbox` e
       }
 
       .paper-item[disabled] {
-        color: var(--paper-item-disabled-color, --disabled-text-color);
+        color: var(--paper-item-disabled-color, var(--disabled-text-color));
         @apply --paper-item-disabled;
       }
 

--- a/element-styles/paper-item.html
+++ b/element-styles/paper-item.html
@@ -1,0 +1,85 @@
+<!--
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../color.html">
+<link rel="import" href="../default-theme.html">
+<link rel="import" href="../typography.html">
+
+<!--
+Material design: [Lists](https://www.google.com/design/spec/components/lists.html)
+
+Shared styles for a native `button` to be used as an item in a `paper-listbox` element:
+
+    <custom-style>
+      <style is="custom-style" include="paper-item"></style>
+    </custom-style>
+
+    <paper-listbox>
+      <button class="paper-item" role="option">Inbox</button>
+      <button class="paper-item" role="option">Starred</button>
+      <button class="paper-item" role="option">Sent mail</button>
+    </paper-listbox>
+
+@group Paper Elements
+@demo demo/index.html
+-->
+
+<dom-module id="paper-item">
+  <template>
+    <style>
+      .paper-item {
+        display: block;
+        position: relative;
+        min-height: var(--paper-item-min-height, 48px);
+        padding: 0px 16px;
+        @apply --paper-font-subhead;
+        border:none;
+        outline: none;
+        background: white;
+        width: 100%;
+        text-align: left;
+      }
+
+      .paper-item[hidden] {
+        display: none !important;
+      }
+
+      .paper-item.iron-selected {
+        font-weight: var(--paper-item-selected-weight, bold);
+        @apply --paper-item-selected;
+      }
+
+      .paper-item[disabled] {
+        color: var(--paper-item-disabled-color, --disabled-text-color);
+        @apply --paper-item-disabled;
+      }
+
+      .paper-item:focus {
+        position: relative;
+        outline: 0;
+        @apply --paper-item-focused;
+      }
+
+      .paper-item:focus:before {
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background: currentColor;
+        content: '';
+        opacity: var(--dark-divider-opacity);
+        pointer-events: none;
+        @apply --paper-item-focused-before;
+      }
+    </style>
+  </template>
+</dom-module>

--- a/element-styles/paper-material.html
+++ b/element-styles/paper-material.html
@@ -1,0 +1,63 @@
+<!--
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../shadow.html">
+
+<!--
+Material design: [Cards](https://www.google.com/design/spec/components/cards.html)
+
+Shared styles that you can apply to an element to renders two shadows on top
+of each other,that create the effect of a lifted piece of paper.
+
+Example:
+
+    <custom-style>
+      <style is="custom-style" include="paper-material"></style>
+    </custom-style>
+
+    <div class="paper-material elevation-1">
+      ... content ...
+    </div>
+
+@group Paper Elements
+@demo demo/index.html
+-->
+
+<dom-module id="paper-material">
+  <template>
+    <style>
+      :host(.paper-material), .paper-material {
+        display: block;
+        position: relative;
+      }
+
+      :host(.paper-material[elevation="1"]), .paper-material[elevation="1"] {
+        @apply --shadow-elevation-2dp;
+      }
+
+      :host(.paper-material[elevation="2"]), .paper-material[elevation="2"] {
+        @apply --shadow-elevation-4dp;
+      }
+
+      :host(.paper-material[elevation="3"]), .paper-material[elevation="3"] {
+        @apply --shadow-elevation-6dp;
+      }
+
+      :host(.paper-material[elevation="4"]), .paper-material[elevation="4"] {
+        @apply --shadow-elevation-8dp;
+      }
+
+      :host(.paper-material[elevation="5"]), .paper-material[elevation="5"] {
+        @apply --shadow-elevation-16dp;
+      }
+    </style>
+  </template>
+</dom-module>


### PR DESCRIPTION
This is needed so that hybrid elements that need to use `paper-material` (like `paper-card` for example) can actually run with the 1.0 dependency of `paper-styles`