### PR TITLE
:host needs to come first because regex

### DIFF
--- a/element-styles/paper-item.html
+++ b/element-styles/paper-item.html
@@ -35,7 +35,7 @@ Shared styles for a native `button` to be used as an item in a `paper-listbox` e
 <dom-module id="paper-item">
   <template>
     <style>
-      html, :host {
+      :host, html {
         --paper-item: {
           display: block;
           position: relative;

--- a/element-styles/paper-material.html
+++ b/element-styles/paper-material.html
@@ -34,7 +34,7 @@ Example:
 <dom-module id="paper-material">
   <template>
     <style>
-      html, :host {
+      :host, html {
         --paper-material: {
           display: block;
           position: relative;


### PR DESCRIPTION
Ok so @azakus said that `:host` needs to come first because he wrote a regex and has regrets.