### PR TITLE
Fix hybrid styles

### DIFF
--- a/color.html
+++ b/color.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <custom-style>
   <style is="custom-style">
-    html {
+    :root, html {
 
       /* Material Design color palette for Google products */
 

--- a/default-theme.html
+++ b/default-theme.html
@@ -15,7 +15,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <custom-style>
   <style is="custom-style">
-    html {
+    :root, html {
       /*
        * You can use these generic variables in your elements for easy theming.
        * For example, if all your elements use `--primary-text-color` as its main

--- a/shadow.html
+++ b/shadow.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <custom-style>
   <style is="custom-style">
-    html {
+    :root, html {
 
       --shadow-transition: {
         transition: box-shadow 0.28s cubic-bezier(0.4, 0, 0.2, 1);

--- a/typography.html
+++ b/typography.html
@@ -21,7 +21,7 @@ Design typography section.
 -->
 <custom-style>
   <style is="custom-style">
-    html {
+    :root, html {
 
       /* Shared Styles */
       --paper-font-common-base: {


### PR DESCRIPTION
Need to use both `:root` and `html` because one works with Polymer 1.0, one works with Polymer 2.0 and neither works in both 🙌 

(see a similar change in https://github.com/PolymerElements/paper-styles/commit/1b797182534dc164f4137b3c001197abe979d53f)