### PR TITLE
feat(typography): font-smoothing for firefox in macOS

### DIFF
--- a/typography.html
+++ b/typography.html
@@ -27,11 +27,13 @@ Design typography section.
       --paper-font-common-base: {
         font-family: 'Roboto', 'Noto', sans-serif;
         -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
       };
 
       --paper-font-common-code: {
         font-family: 'Roboto Mono', 'Consolas', 'Menlo', monospace;
         -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
       };
 
       --paper-font-common-expensive-kerning: {


### PR DESCRIPTION
Improve font smoothing in firefox in macOS by add `-moz-osx-font-smoothing: grayscale;`