### PR TITLE
Add docs pertaining to creating your own theme

### DIFF
--- a/paper-styles.html
+++ b/paper-styles.html
@@ -35,7 +35,7 @@ Create your own global theme to override components that use paper-styles by cre
 <link rel="import" href="bower_components/polymer/lib/elements/custom-style.html">
 <custom-style>
   <style is="custom-style">
-    :root {
+    html {
       --primary-color: var(--paper-green-500);
       --accent-color: var(--paper-deep-orange-500);
     }

--- a/paper-styles.html
+++ b/paper-styles.html
@@ -30,6 +30,19 @@ used in the PolymerElements demo pages
 We recommend importing each of these individual files, and using the style mixins
 available in each ones, rather than the aggregated `paper-styles.html` as a whole.
 
+Create your own global theme to override components that use paper-styles by creating a component file as follows and importing it into your index.html.
+```
+<link rel="import" href="bower_components/polymer/lib/elements/custom-style.html">
+<custom-style>
+  <style is="custom-style">
+    :root {
+      --primary-color: var(--paper-green-500);
+      --accent-color: var(--paper-deep-orange-500);
+    }
+  </style>
+</custom-style>
+```
+
 @group Paper Elements
 @pseudoElement paper-styles
 @demo demo/index.html

--- a/paper-styles.html
+++ b/paper-styles.html
@@ -30,7 +30,8 @@ used in the PolymerElements demo pages
 We recommend importing each of these individual files, and using the style mixins
 available in each ones, rather than the aggregated `paper-styles.html` as a whole.
 
-Create your own global theme to override components that use paper-styles by creating a component file as follows and importing it into your index.html.
+Create your own global theme to override components that use paper-styles by creating a component file as follows and 
+then import it into your index.html or app component using html imports like you do with other web components.
 ```
 <link rel="import" href="bower_components/polymer/lib/elements/custom-style.html">
 <custom-style>


### PR DESCRIPTION
I'm not sure if this is the right place to start this documentation but it would have saved me couple of hours of searching around issue queues and guessing if it had been here. Creating your own custom theme, at least overriding primary and accent colors, seems like a common use case when also using paper-styles.