### PR TITLE
Update README: Changed links to js files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,23 +3,23 @@
 [![Published on webcomponents.org](https://img.shields.io/badge/webcomponents.org-published-blue.svg)](https://webcomponents.org/element/@polymer/paper-styles)
 
 ## &lt;paper-styles&gt;
-1. [default-theme.js](https://github.com/PolymerElements/paper-styles/blob/master/default-theme.html): text,
+1. [default-theme.js](https://github.com/PolymerElements/paper-styles/blob/master/default-theme.js): text,
 background and accent colors that match the default Material Design theme
 
-1. [shadow.js](https://github.com/PolymerElements/paper-styles/blob/master/shadow.html): Material Design
+1. [shadow.js](https://github.com/PolymerElements/paper-styles/blob/master/shadow.js): Material Design
 [elevation](https://material.io/design/environment/light-shadows.html#shadows) and shadow styles
 
-1. [typography.js](https://github.com/PolymerElements/paper-styles/blob/master/typography.html):
+1. [typography.js](https://github.com/PolymerElements/paper-styles/blob/master/typography.js):
 Material Design [font](http://www.google.com/design/spec/style/typography.html#typography-styles) styles and sizes
 
-1. [demo-pages.js](https://github.com/PolymerElements/paper-styles/blob/master/demo-pages.html): generic styles
+1. [demo-pages.js](https://github.com/PolymerElements/paper-styles/blob/master/demo-pages.js): generic styles
 used in the PolymerElements demo pages
 
-1. [color.js](https://github.com/PolymerElements/paper-styles/blob/master/color.html):
+1. [color.js](https://github.com/PolymerElements/paper-styles/blob/master/color.js):
 a complete list of the colors defined in the Material Design [palette](https://www.google.com/design/spec/style/color.html)
 
 We recommend importing each of these individual files, and using the style mixins
-available in each ones, rather than the aggregated `paper-styles.html` as a whole.
+available in each ones, rather than the aggregated `paper-styles.js` as a whole.
 
 See: [Documentation](https://www.webcomponents.org/element/@polymer/paper-styles),
   [Demo](https://www.webcomponents.org/element/@polymer/paper-styles/demo/demo/index.html).


### PR DESCRIPTION
Some of the links in the README where to .html files that didn't exist. Changed to .js